### PR TITLE
exclude device we don't support by default

### DIFF
--- a/custom_components/deebot/hub.py
+++ b/custom_components/deebot/hub.py
@@ -16,6 +16,10 @@ DEEBOT_API_DEVICEID = "".join(
     random.choice(string.ascii_uppercase + string.digits) for _ in range(8)
 )
 
+DEEBOT_COMPANY_EXCLUDE = ["eco-legacy"]
+DEEBOT_MODEL_EXCLUDE = []
+DEEBOT_DEVICENAME_EXCLUDE = []
+
 
 class DeebotHub:
     """Deebot Hub"""
@@ -49,6 +53,11 @@ class DeebotHub:
 
         # CREATE VACBOT FOR EACH DEVICE
         for device in devices:
+            if device["company"] in DEEBOT_COMPANY_EXCLUDE or device["model"] in DEEBOT_MODEL_EXCLUDE or device["deviceName"] in DEEBOT_DEVICENAME_EXCLUDE:
+                _LOGGER.debug("Device '{}' skipped due to being in the excluded list, device details: {}".format(
+                  device["name"], device))
+                continue
+
             if device["name"] in domain_config.get(CONF_DEVICES):
                 vacbot = VacBot(
                     self.ecovacs_api.uid,


### PR DESCRIPTION
A number of details around the device model are in the data that comes back from the API.

What do you think about excluding these by default?