### PR TITLE
Store client device id in config

### DIFF
--- a/custom_components/deebot/config_flow.py
+++ b/custom_components/deebot/config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.const import CONF_MODE, CONF_DEVICES
 from homeassistant.helpers import aiohttp_client
 
 from .const import *
+from .helpers import get_bumper_device_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ USER_DATA_SCHEMA = vol.Schema(
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Deebot."""
 
-    VERSION = 2
+    VERSION = 3
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self) -> None:
@@ -94,7 +95,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self.mode = user_input.get(CONF_MODE, CONF_MODE_CLOUD)
             if self.mode == CONF_MODE_BUMPER:
-                return await self.async_step_user(user_input=BUMPER_CONFIGURATION)
+                config = {
+                    **BUMPER_CONFIGURATION,
+                    CONF_CLIENT_DEVICE_ID: get_bumper_device_id(self.hass)
+                }
+                return await self.async_step_user(user_input=config)
 
             return await self.async_step_user()
 

--- a/custom_components/deebot/const.py
+++ b/custom_components/deebot/const.py
@@ -25,19 +25,10 @@ If you have any issues with this you need to open an issue here:
 
 CONF_COUNTRY = "country"
 CONF_CONTINENT = "continent"
-DEEBOT_DEVICES = f"{DOMAIN}_devices"
-VACUUMSTATE_TO_STATE = {
-    VacuumState.STATE_IDLE: STATE_IDLE,
-    VacuumState.STATE_CLEANING: STATE_CLEANING,
-    VacuumState.STATE_RETURNING: STATE_RETURNING,
-    VacuumState.STATE_DOCKED: STATE_DOCKED,
-    VacuumState.STATE_ERROR: STATE_ERROR,
-    VacuumState.STATE_PAUSED: STATE_PAUSED,
-}
-
 CONF_BUMPER = "Bumper"
 CONF_MODE_BUMPER = CONF_BUMPER
 CONF_MODE_CLOUD = "Cloud (recommended)"
+CONF_CLIENT_DEVICE_ID = "client_device_id"
 
 # Bumper has no auth and serves the urls for all countries/continents
 BUMPER_CONFIGURATION = {
@@ -46,6 +37,17 @@ BUMPER_CONFIGURATION = {
     CONF_PASSWORD: CONF_BUMPER,
     CONF_USERNAME: CONF_BUMPER,
     CONF_VERIFY_SSL: False  # required as bumper is using self signed certificates
+}
+
+DEEBOT_DEVICES = f"{DOMAIN}_devices"
+
+VACUUMSTATE_TO_STATE = {
+    VacuumState.STATE_IDLE: STATE_IDLE,
+    VacuumState.STATE_CLEANING: STATE_CLEANING,
+    VacuumState.STATE_RETURNING: STATE_RETURNING,
+    VacuumState.STATE_DOCKED: STATE_DOCKED,
+    VacuumState.STATE_ERROR: STATE_ERROR,
+    VacuumState.STATE_PAUSED: STATE_PAUSED,
 }
 
 LAST_ERROR = "last_error"

--- a/custom_components/deebot/helpers.py
+++ b/custom_components/deebot/helpers.py
@@ -1,10 +1,14 @@
+from typing import Optional, Dict
+
 from deebotozmo.models import Vacuum
 from deebotozmo.vacuum_bot import VacuumBot
+from homeassistant.core import HomeAssistant
+from homeassistant.util import uuid
 
 from .const import DOMAIN
 
 
-def get_device_info(vacuum_bot: VacuumBot):
+def get_device_info(vacuum_bot: VacuumBot) -> Optional[Dict]:
     device: Vacuum = vacuum_bot.vacuum
     identifiers = set()
     if device.did:
@@ -23,3 +27,11 @@ def get_device_info(vacuum_bot: VacuumBot):
         "model": device.get("deviceName", "Deebot vacuum"),
         "sw_version": vacuum_bot.fw_version,
     }
+
+
+def get_bumper_device_id(hass: HomeAssistant) -> str:
+    try:
+        location_name = hass.config.location_name.strip().replace(' ', '_')
+    except:
+        location_name = ""
+    return f"Deebot-4-HA_{location_name}_{uuid.random_uuid_hex()[:4]}"

--- a/custom_components/deebot/hub.py
+++ b/custom_components/deebot/hub.py
@@ -34,13 +34,9 @@ class DeebotHub:
         self._session: aiohttp.ClientSession = aiohttp_client.async_get_clientsession(self._hass,
                                                                                       verify_ssl=self._verify_ssl)
 
-        if config.get(CONF_USERNAME) == CONF_BUMPER:
-            try:
-                location_name = hass.config.location_name.strip().replace(' ', '_')
-            except:
-                location_name = ""
-            device_id = f"Deebot-4-HA_{location_name}"
-        else:
+        device_id = config.get(CONF_CLIENT_DEVICE_ID)
+
+        if not device_id:
             # Generate a random device ID on each bootup
             device_id = "".join(
                 random.choice(string.ascii_uppercase + string.digits) for _ in range(12)


### PR DESCRIPTION
Store the client device id in the config to use always the same id.
This is currently only used if you select bumper.

@And3rsL Do we need really change the client device id on each startup for cloud instances?

Main reason to set it fixed was for debugging. So I can see in the bumper logs, which requests belongs to which instance.
I also noticed, that the ecovacs app uses always the same id on the same device.